### PR TITLE
chores(): invalid conf in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,12 @@ WORKDIR /usr/app
 COPY ./.next ./.next
 COPY ./public ./public
 COPY ./package*.json .
+COPY ./src ./src
 COPY ./next* .
 
 RUN npm ci --omit=dev --ignore-scripts
+
+ENV NEXT_SHARP_PATH=./node_modules/sharp
 
 # Exposition du port 3000
 EXPOSE 3000

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,6 +6,7 @@ module.exports = defineConfig({
 		defaultCommandTimeout: 30000,
 		numTestsKeptInMemory: 50, // Par défaut 50, mais si un jour les tests crash pour "out of memory" ne pas hésiter à baisser cette valeur.
 		video: true,
+		blockHosts: '*.google-analytics.com',
 		chromeWebSecurity: false,
 		reporter: 'junit',
 		reporterOptions: {

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -77,7 +77,7 @@ const options = {
 	session: {
 		strategy: 'jwt',
 	},
-	debug: true,
+	debug: process.env.NODE_ENV !== 'production',
 	callbacks: {
 		async session({ session, token, user }) {
 			session.jwt = token.jwt


### PR DESCRIPTION
🐛 corriger(Dockerfile) : ajouter la copie du répertoire src dans l'image Docker

🐛 corriger(cypress.config.js) : bloquer les requêtes vers "*.google-analytics.com" 

🐛 corriger([...nextauth].js) : désactiver le mode de débogage en production Le répertoire src est maintenant copié dans l'image Docker, ce qui permet à l'application d'avoir accès aux fichiers source nécessaires à son fonctionnement. Les requêtes vers "*.google-analytics.com" sont maintenant bloquées lors de l'exécution des tests Cypress pour éviter les appels indésirables à Google Analytics. Le mode de débogage est désactivé en production pour des raisons de sécurité et de performances.