### PR TITLE
corriger le crash dans la recherche de mauilleuse si pas images de profile

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,3 @@
 {
-	"extends": ["next/core-web-vitals", "prettier"],
-	"plugins": ["yaml"]
+	"extends": ["next/core-web-vitals", "prettier"]
 }

--- a/cypress/e2e/auth/profil.cy.js
+++ b/cypress/e2e/auth/profil.cy.js
@@ -863,7 +863,7 @@ describe('profil', () => {
 																																																																											)
 
 																																																																										cy.wait(
-																																																																											250
+																																																																											2000
 																																																																										)
 																																																																										cy.get(
 																																																																											"[data-cy='completion-pourcentage-profil']"

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -114,15 +114,29 @@ function SearchPage() {
 												}
 											>
 												<div className={'relative w-full'}>
-													<Image
-														src={result.main_picture.url}
-														alt={'profil picture Maquilleuse professionnelle'}
-														width={200}
-														height={200}
-														className={
-															'h-[350px] w-full rounded-b-none rounded-t object-cover object-center'
-														}
-													/>
+													{result.main_picture === null && (
+														<Image
+															src={'/assets/pp_makeup.webp'}
+															alt={'profil picture Maquilleuse professionnelle'}
+															width={250}
+															height={250}
+															quality={100}
+															className={
+																'h-[350px] w-full rounded-b-none rounded-t object-cover object-center'
+															}
+														/>
+													)}
+													{result.main_picture != null && (
+														<Image
+															src={result.main_picture.url}
+															alt={'profil picture Maquilleuse professionnelle'}
+															width={250}
+															height={250}
+															className={
+																'h-[350px] w-full rounded-b-none rounded-t object-cover object-center'
+															}
+														/>
+													)}
 													{result?.pro === true && (
 														<div
 															className={


### PR DESCRIPTION
#419 

🔧 corriger(profil.cy.js) : augmenter le délai d'attente de 250 à 2000 millisecondes Le plugin "yaml" a été supprimé de la configuration ESLint car il n'est plus utilisé. L'augmentation du délai d'attente dans le fichier profil.cy.js permet de s'assurer que l'élément "[data-cy='completion-pourcentage-profil']" est correctement récupéré après l'attente.

🐛 corriger(search.js) : ajouter des points-virgules manquants à la fin des déclarations de variables
✨ fonctionnalité(search.js) : ajouter une image par défaut si la maquilleuse n'a pas de photo de profil
🐛 corriger(search.js) : corriger la casse des attributs HTML dans les balises meta et link
✨ fonctionnalité(search.js) : ajouter une icône de vérification à côté du nom de la maquilleuse si elle est certifiée
🐛 corriger(search.js) : corriger la classe CSS pour l'icône de direction
✨ fonctionnalité(search.js) : afficher les compétences de la maquilleuse avec une limite de 7 compétences visibles
✨ fonctionnalité(search.js) : afficher une liste de services proposés par la maquille