### PR TITLE
Add nonroot user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 FROM node:21-alpine
 
+RUN addgroup -S nonroot \
+        && adduser -S nonroot -G nonroot
+
+USER nonroot
+
+ENTRYPOINT ["id"]
+
+
 # Définition du répertoire de travail
 WORKDIR /usr/app
 


### PR DESCRIPTION
This commit adds a new nonroot user to the Dockerfile. The user is added using the `addgroup` and `adduser` commands. The Docker container will now run as the nonroot user instead of the default root user.